### PR TITLE
fix(android): route vendor HW decode formats to zero-copy YCbCr pipeline

### DIFF
--- a/crates/lumina-video/src/media/video_texture.rs
+++ b/crates/lumina-video/src/media/video_texture.rs
@@ -1221,7 +1221,7 @@ mod native_render_callback {
                     )
                 {
                     use crate::media::android_video::{
-                        is_yuv_hardware_buffer_format, is_yv12_format,
+                        is_yuv_candidate_hardware_buffer_format, is_yv12_format,
                         AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM,
                     };
 
@@ -1309,7 +1309,7 @@ mod native_render_callback {
                                 }
                             }
                         }
-                    } else if is_yuv_hardware_buffer_format(frame.format) {
+                    } else if is_yuv_candidate_hardware_buffer_format(frame.format) {
                         // YUV path - try true zero-copy first, fall back to CPU-assisted path
                         //
                         // True zero-copy: Uses raw Vulkan to import YUV planes and do GPU-side

--- a/crates/lumina-video/src/media/zero_copy.rs
+++ b/crates/lumina-video/src/media/zero_copy.rs
@@ -2009,7 +2009,7 @@ pub mod android {
                             ahb_external_format
                         );
                         return Err(ZeroCopyError::NotAvailable(
-                            "External-format AHardwareBuffers require VkExternalFormatANDROID which is not yet implemented".to_string(),
+                            "External-format AHardwareBuffers are not supported in RGBA import; use import_ahardwarebuffer_yuv_zero_copy".to_string(),
                         ));
                     }
 


### PR DESCRIPTION
## Summary
- Vendor-proprietary formats (Qualcomm UBWC, Samsung SBWC, MediaTek AFBC, Google Tensor) from MediaCodec were falling through to a dead-end `else` branch in `video_texture.rs`, dropping frames and falling back to CPU
- Added `is_yuv_candidate_hardware_buffer_format()` — a broad routing helper that treats anything non-RGBA as a YUV candidate — so vendor formats reach the existing `import_ahb_yuv_external_format()` zero-copy pipeline
- The strict `is_yuv_hardware_buffer_format()` remains unchanged for PixelFormat metadata in `moq_decoder.rs`

Closes #9

## Files changed
| File | Change |
|------|--------|
| `android_video.rs` | Add `is_yuv_candidate_hardware_buffer_format()` + 5 unit tests |
| `video_texture.rs` | Use broad candidate helper for format routing |
| `zero_copy.rs` | Fix stale error message in RGBA import path |

## Test results so far
- [x] `cargo check`, `cargo fmt`, `cargo clippy -- -D warnings` — all clean
- [x] `cargo test -p lumina-video` — 38 tests pass
- [x] Cross-compiled for `aarch64-linux-android` (NDK 27.0) — 5 format routing tests in binary
- [x] `moq_decoder.rs:2717` still uses strict `is_yuv_hardware_buffer_format` (no semantic drift)
- [x] **Regression test on Daylight DC-1** (MediaTek MT6789, Android 13): video plays, zero-copy YV12 path works, no breakage. Device outputs standard YV12 so existing path confirmed working.
- [ ] **Vendor format validation** — needs a Snapdragon/Exynos/Tensor device (see below)

## Step-by-step test instructions

### 0. Prerequisites

You need all of the following installed:

| Requirement | How to check | Install if missing |
|---|---|---|
| Rust toolchain | `rustc --version` | [rustup.rs](https://rustup.rs/) |
| Android target | `rustup target list --installed \| grep android` | `rustup target add aarch64-linux-android` |
| cargo-ndk | `cargo ndk --version` | `cargo install cargo-ndk` |
| Android SDK | `echo $ANDROID_HOME` | [Android Studio](https://developer.android.com/studio) or `brew install android-commandlinetools` |
| Android NDK 26.x | `ls $ANDROID_HOME/ndk/` | `sdkmanager "ndk;26.1.10909125"` |
| JDK 17 | `java -version` | `brew install temurin@17` or [Adoptium](https://adoptium.net/) |
| Connected device | `adb devices` (should show a device ID) | Enable USB debugging in device Settings > Developer Options |

**Environment variables** — if `ANDROID_HOME` or `ANDROID_NDK_HOME` are not set, find and export them:

```bash
# Common SDK locations:
#   macOS (homebrew): /opt/homebrew/share/android-commandlinetools
#   macOS (Android Studio): ~/Library/Android/sdk
#   Linux: ~/Android/Sdk
export ANDROID_HOME=/path/to/your/sdk
export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/26.1.10909125  # adjust version to what you have
```

### 1. Clone and checkout

```bash
git clone https://github.com/lumina-video/lumina-video.git
cd lumina-video
git checkout fix/android-vendor-format-routing
```

### 2. Build native library

**Important:** You must pass `-P 26` (or higher) to set the minimum Android API level. The default (API 21) will fail with `unable to find library -laaudio`.

```bash
cargo ndk -t arm64-v8a -P 26 build \
  --package lumina-video-android --release
```

This takes ~2 minutes on first build. You should see `Finished release` at the end.

### 3. Copy .so to jniLibs

```bash
mkdir -p android/app/src/main/jniLibs/arm64-v8a
cp target/aarch64-linux-android/release/liblumina_video_android.so \
   android/app/src/main/jniLibs/arm64-v8a/
```

### 4. Build the APK

```bash
# Point Gradle to your SDK
echo "sdk.dir=$ANDROID_HOME" > android/local.properties

# Build (runs from repo root)
cd android && ./gradlew assembleDebug
```

You should see `BUILD SUCCESSFUL`. The APK is at `app/build/outputs/apk/debug/app-debug.apk`.

### 5. Install and launch

```bash
# Verify device is connected
adb devices
# Should show your device ID, e.g.:
#   JPCQ00300    device

# Install
adb install -r app/build/outputs/apk/debug/app-debug.apk

# Clear old logs and launch
adb logcat -c
adb shell am start -n com.luminavideo.demo/.MainActivity
```

### 6. Verify it works

**Visually:** The app should show a sample video (android-screens-10s.mp4) playing with audio. If you see video and hear audio, the rendering pipeline is working.

**Via logs** (wait ~5 seconds for frames to start decoding):

```bash
adb logcat -d | grep -E "HardwareBuffer frame|external YUV|unsupported HardwareBuffer|import successful"
```

#### Success on Snapdragon/Exynos/Tensor (vendor format — this is what the fix targets):
```
I lumina-video: Received HardwareBuffer frame: 1280x720 format=0x7fa30c06
D lumina-video: AHardwareBuffer external YUV format: external_format=...
I lumina-video: Android frame import successful, texture ready for rendering
```
The vendor format was routed to the zero-copy YCbCr pipeline. Fix confirmed.

#### Success on MediaTek/standard format devices (regression test):
```
I lumina-video: Received HardwareBuffer frame: 1280x720 format=0x32315659
I lumina-video: Android frame import successful, texture ready for rendering
```
YV12 — takes the existing path. Confirms no regression.

#### Failure (should NOT happen on this branch):
```
W lumina-video: Android zero-copy: unsupported HardwareBuffer format 0x7fa30c06. Using CPU fallback.
```
The vendor format was NOT routed correctly.

## Devices that exercise the vendor format path

To fully validate the fix, you need a device whose MediaCodec outputs vendor-compressed formats (not standard NV12/YV12):

| Device | SoC | Expected format |
|--------|-----|-----------------|
| **Samsung Galaxy S21** | Snapdragon 888 | UBWC `0x7FA30C06` |
| Samsung Galaxy S22/S23 | Snapdragon 8 Gen 1/2 | UBWC `0x7FA30C06` |
| Google Pixel 3/4/5 | Snapdragon 845/855/765G | UBWC `0x7FA30C06` |
| Google Pixel 6/7/8 | Tensor G1/G2/G3 | AFBC (Mali) |
| Samsung Galaxy S20 (intl) | Exynos 990 | SBWC |
| OnePlus 6+ | Snapdragon 845+ | UBWC `0x7FA30C06` |

Cheapest option: any used Pixel 3-5 (~$50) has Snapdragon + UBWC.

Devices that will NOT exercise the fix (but are useful as regression tests): MediaTek devices like the Daylight DC-1 that output standard YV12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)