### PR TITLE
docs(android): fix build instructions that fail on fresh setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,22 +189,23 @@ trunk serve --open
 <details>
 <summary><b>Android</b></summary>
 
-**Prerequisites:** [Rust toolchain](https://rustup.rs/), Android SDK (API 35), Android NDK 26.x, connected device or emulator
+**Prerequisites:** [Rust toolchain](https://rustup.rs/), Android SDK (API 35), Android NDK 26.x, `ANDROID_NDK_HOME` env var set, connected device
 
 ```bash
 # Add Android target and install cargo-ndk
 rustup target add aarch64-linux-android
 cargo install cargo-ndk
 
-# Build native library
-cargo ndk -t arm64-v8a build --package lumina-video-android --release
+# Build native library (-P 26 required — default API 21 is missing libaaudio)
+cargo ndk -t arm64-v8a -P 26 build --package lumina-video-android --release
 
 # Copy to jniLibs
 mkdir -p android/app/src/main/jniLibs/arm64-v8a
 cp target/aarch64-linux-android/release/liblumina_video_android.so \
    android/app/src/main/jniLibs/arm64-v8a/
 
-# Build and install APK
+# Set SDK path and build APK
+echo "sdk.dir=$ANDROID_HOME" > android/local.properties
 cd android && ./gradlew assembleDebug
 adb install -r app/build/outputs/apk/debug/app-debug.apk
 ```


### PR DESCRIPTION
## Summary
- Add `-P 26` flag to `cargo ndk` commands (default API 21 is missing `libaaudio`, causing linker failure)
- Use `$ANDROID_HOME` for `local.properties` instead of hardcoded `~/Library/Android/sdk` (wrong for homebrew installs)
- Document `ANDROID_NDK_HOME` env var requirement (cargo-ndk silently fails without it)
- Fix library name in expected log output (`liblumina_video_android.so`, not `liblumina_video.so`)
- Add troubleshooting entries for the two most common first-time build failures

Found while testing PR #16 on a real device — every issue listed here was hit during an actual build.

## Test plan
- [x] Successfully built and deployed to Daylight DC-1 (Android 13) using these exact instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)