### PR TITLE
ci(macos): add DMG release workflow

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -148,10 +148,17 @@ jobs:
 </plist>
 PLIST
 
-          # Copy icon if available
-          if [ -f "crates/lumina-video-demo/assets/lumina-video-icon-ferris-hybrid.png" ]; then
-            cp "crates/lumina-video-demo/assets/lumina-video-icon-ferris-hybrid.png" \
-               "${APP_DIR}/Contents/Resources/AppIcon.png"
+          # Convert PNG icon to .icns for Finder/Dock
+          ICON_SRC="crates/lumina-video-demo/assets/lumina-video-icon-ferris-hybrid.png"
+          if [ -f "$ICON_SRC" ]; then
+            ICONSET_DIR=$(mktemp -d)/AppIcon.iconset
+            mkdir -p "$ICONSET_DIR"
+            for SIZE in 16 32 128 256 512; do
+              sips -z $SIZE $SIZE "$ICON_SRC" --out "$ICONSET_DIR/icon_${SIZE}x${SIZE}.png" >/dev/null
+              DOUBLE=$((SIZE * 2))
+              sips -z $DOUBLE $DOUBLE "$ICON_SRC" --out "$ICONSET_DIR/icon_${SIZE}x${SIZE}@2x.png" >/dev/null
+            done
+            iconutil -c icns "$ICONSET_DIR" -o "${APP_DIR}/Contents/Resources/AppIcon.icns"
           fi
 
       - name: Verify app bundle
@@ -178,6 +185,7 @@ PLIST
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
           APP_NAME="Lumina Video Demo"
           DMG_NAME="lumina-video-demo-${VERSION}-macos-${{ matrix.arch }}"
 


### PR DESCRIPTION
## Summary
- Add `release-macos.yml` workflow that builds `.dmg` installers on GitHub release publish
- Builds three variants: **arm64** (Apple Silicon), **x86_64** (Intel), and **universal** binary
- Bundles FFmpeg dylibs via `install_name_tool` rewriting so DMG is self-contained
- Creates proper `.app` bundle with `Info.plist`, drag-to-Applications DMG layout
- Safe GitHub expression handling (env vars, no script injection)
- Also supports `workflow_dispatch` for manual testing

## What the workflow does
1. Builds `lumina-video-demo` for both `aarch64-apple-darwin` and `x86_64-apple-darwin`
2. Creates `.app` bundles with bundled FFmpeg frameworks
3. Packages into `.dmg` with Applications symlink
4. Creates universal binary DMG via `lipo`
5. Uploads all three DMGs as release assets

## Release assets produced
- `lumina-video-demo-{version}-macos-arm64.dmg`
- `lumina-video-demo-{version}-macos-x86_64.dmg`
- `lumina-video-demo-{version}-macos-universal.dmg`

## Test plan
- [ ] Trigger via workflow_dispatch to verify build succeeds
- [ ] Download arm64 DMG, mount, drag to Applications, launch
- [ ] Verify FFmpeg dylibs are bundled (no Homebrew dependency at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added an automated macOS build-and-release pipeline producing architecture-specific (arm64, x86_64) DMGs and a combined universal DMG.
  * Packaging now embeds required media libraries, validates app bundles, includes app icons, generates checksums, and uploads artifacts.
  * Releases are auto-published with consolidated assets for easy download.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->