### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-package.version = "0.2.1"
+package.version = "0.2.2"
 members = [
     "crates/lumina-video",
     "crates/lumina-video-demo",


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.2.1 to 0.2.2

Version bump for release. See release notes for full changelog.