### PR TITLE
feat(ios): MoQ audio playback with resampling + stale sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -949,6 +949,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "conducer"
+version = "0.3.0"
+source = "git+https://github.com/kixelated/moq?rev=ca7fb4bc37c2b01fe5fb2ee735c5511e62b531ce#ca7fb4bc37c2b01fe5fb2ee735c5511e62b531ce"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,7 +1581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1906,7 +1911,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2302,13 +2307,13 @@ dependencies = [
 
 [[package]]
 name = "hang"
-version = "0.14.0"
-source = "git+https://github.com/kixelated/moq?rev=baabd55c7a8dd6c85d6e1e329a776208bd1107ca#baabd55c7a8dd6c85d6e1e329a776208bd1107ca"
+version = "0.15.1"
+source = "git+https://github.com/kixelated/moq?rev=ca7fb4bc37c2b01fe5fb2ee735c5511e62b531ce#ca7fb4bc37c2b01fe5fb2ee735c5511e62b531ce"
 dependencies = [
  "buf-list",
  "bytes",
+ "conducer",
  "derive_more",
- "futures",
  "hex",
  "lazy_static",
  "moq-lite",
@@ -2531,7 +2536,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3079,6 +3084,7 @@ dependencies = [
  "lumina-video-core",
  "parking_lot",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3199,11 +3205,11 @@ dependencies = [
 
 [[package]]
 name = "moq-lite"
-version = "0.14.0"
-source = "git+https://github.com/kixelated/moq?rev=baabd55c7a8dd6c85d6e1e329a776208bd1107ca#baabd55c7a8dd6c85d6e1e329a776208bd1107ca"
+version = "0.15.0"
+source = "git+https://github.com/kixelated/moq?rev=ca7fb4bc37c2b01fe5fb2ee735c5511e62b531ce#ca7fb4bc37c2b01fe5fb2ee735c5511e62b531ce"
 dependencies = [
- "async-channel",
  "bytes",
+ "conducer",
  "futures",
  "hex",
  "num_enum",
@@ -3218,8 +3224,8 @@ dependencies = [
 
 [[package]]
 name = "moq-native"
-version = "0.13.1"
-source = "git+https://github.com/kixelated/moq?rev=baabd55c7a8dd6c85d6e1e329a776208bd1107ca#baabd55c7a8dd6c85d6e1e329a776208bd1107ca"
+version = "0.13.2"
+source = "git+https://github.com/kixelated/moq?rev=ca7fb4bc37c2b01fe5fb2ee735c5511e62b531ce#ca7fb4bc37c2b01fe5fb2ee735c5511e62b531ce"
 dependencies = [
  "anyhow",
  "clap",
@@ -3433,7 +3439,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4388,7 +4394,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4689,7 +4695,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4757,7 +4763,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6305,9 +6311,9 @@ dependencies = [
 
 [[package]]
 name = "web-async"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b2260b739b0e95cf9b78f22a64704af7ed9760ea12baa3745b4b97899dc89a"
+checksum = "f5414b65d9a5094649bb99987bb74db71febfdfa3677b7954a0a05c99d0424e8"
 dependencies = [
  "tokio",
  "tracing",
@@ -6384,9 +6390,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-trait"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2615c30ed29953bb3727391850279a25c948c0b7a4ed2343d3a78e1d3cce2f7c"
+checksum = "802d6aa508f2c63c9050ceabc17265bbf90ed4d6f4e4357e987583883628e79c"
 dependencies = [
  "bytes",
 ]
@@ -6583,7 +6589,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/lumina-video-core/src/audio.rs
+++ b/crates/lumina-video-core/src/audio.rs
@@ -93,6 +93,9 @@ struct AudioHandleInner {
     /// True when cpal callback detects sustained ring buffer underrun.
     /// Set by cpal callback (audio thread), read by FrameScheduler (UI thread).
     audio_stalled: AtomicBool,
+    /// True when playback is paused. Set by CorePlayer, read by cpal callback.
+    /// This is the cross-thread pause signal that works for both FFmpeg and MoQ audio paths.
+    paused: AtomicBool,
 }
 
 impl AudioHandle {
@@ -112,6 +115,7 @@ impl AudioHandle {
                 video_start_time_us_plus1: AtomicU64::new(0),
                 native_position_us: AtomicU64::new(0),
                 audio_stalled: AtomicBool::new(false),
+                paused: AtomicBool::new(false),
             }),
         }
     }
@@ -140,6 +144,16 @@ impl AudioHandle {
     pub fn toggle_mute(&self) {
         // Use fetch_xor for atomic toggle to avoid TOCTOU race condition
         self.inner.muted.fetch_xor(true, Ordering::Relaxed);
+    }
+
+    /// Returns whether playback is paused.
+    pub fn is_paused(&self) -> bool {
+        self.inner.paused.load(Ordering::Acquire)
+    }
+
+    /// Sets the paused state.
+    pub fn set_paused(&self, paused: bool) {
+        self.inner.paused.store(paused, Ordering::Release);
     }
 
     /// Returns the effective volume (0.0-1.0) accounting for mute.
@@ -783,7 +797,7 @@ mod cpal_impl {
             .build_output_stream(
                 config,
                 move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
-                    if !playing.load(Ordering::Acquire) {
+                    if !playing.load(Ordering::Acquire) || handle.is_paused() {
                         let zero = T::from_sample(0.0f32);
                         data.fill(zero);
                         return;

--- a/crates/lumina-video-core/src/frame_queue.rs
+++ b/crates/lumina-video-core/src/frame_queue.rs
@@ -1171,6 +1171,12 @@ pub struct FrameScheduler {
     /// Last time get_next_frame() was called (for rendering gap detection).
     /// A gap > RENDERING_GAP_THRESHOLD indicates the app was backgrounded.
     last_get_next_frame_time: Option<std::time::Instant>,
+    /// Last observed audio position from sync_position() — for stale detection.
+    last_observed_audio_pos: Duration,
+    /// Wall-clock time when `last_observed_audio_pos` last changed.
+    last_audio_pos_change: Option<std::time::Instant>,
+    /// True when audio has been detected as stale (not advancing).
+    audio_sync_stale: bool,
 }
 
 impl FrameScheduler {
@@ -1219,6 +1225,9 @@ impl FrameScheduler {
             initial_pts_bias_applied: false,
             deferred_epoch_pts: None,
             last_get_next_frame_time: None,
+            last_observed_audio_pos: Duration::ZERO,
+            last_audio_pos_change: None,
+            audio_sync_stale: false,
         }
     }
 
@@ -1247,6 +1256,30 @@ impl FrameScheduler {
         self.use_audio_as_sync_master = false;
     }
 
+    /// Rebases the wall-clock origin to the current audio position.
+    ///
+    /// Call when promoting from metrics-only to audio-as-sync-master to
+    /// eliminate the position discontinuity between where wall-clock had
+    /// advanced and where audio actually is.
+    pub fn resync_clock_to_audio(&mut self) {
+        let audio_pos = self.audio_position();
+        if audio_pos > Duration::ZERO {
+            let now = std::time::Instant::now();
+            self.playback_start_position = audio_pos;
+            self.playback_start_time = Some(now);
+            self.current_position = audio_pos;
+            self.last_observed_audio_pos = audio_pos;
+            self.last_audio_pos_change = Some(now);
+            self.audio_sync_stale = false;
+            self.reset_drift_correction();
+            self.sync_metrics.set_grace_period(10);
+            tracing::info!(
+                "FrameScheduler: resynced clock to audio position {:?}",
+                audio_pos,
+            );
+        }
+    }
+
     /// Clears the audio handle, falling back to wall-clock for frame pacing.
     pub fn clear_audio_handle(&mut self) {
         self.audio_handle = None;
@@ -1260,6 +1293,9 @@ impl FrameScheduler {
         self.audio_stall_start = None;
         self.ignore_audio_stall_until_recovered = false;
         self.last_get_next_frame_time = None;
+        self.last_observed_audio_pos = Duration::ZERO;
+        self.last_audio_pos_change = None;
+        self.audio_sync_stale = false;
         self.reset_drift_correction();
     }
 
@@ -1381,7 +1417,7 @@ impl FrameScheduler {
     /// - No audio handle is set
     /// - Audio is not available
     /// - Audio hasn't started yet (position == 0)
-    fn sync_position(&self) -> Duration {
+    fn sync_position(&mut self) -> Duration {
         // Get wall-clock position as baseline
         let wall_clock_pos = self.position();
 
@@ -1397,10 +1433,45 @@ impl FrameScheduler {
                 let audio_pos = audio.position_for_sync();
                 // Only use audio position if audio has actually started
                 if audio_pos > Duration::ZERO {
-                    // Once audio has started, always use it as master clock.
-                    // Don't fall back to wall-clock even if audio is behind -
-                    // video should slow down to match audio, not race ahead.
-                    return audio_pos;
+                    // Detect stale audio: if position hasn't changed in >2s,
+                    // fall back to wall-clock to prevent video freeze.
+                    const AUDIO_STALE_THRESHOLD: Duration = Duration::from_secs(2);
+                    let now = std::time::Instant::now();
+                    if audio_pos != self.last_observed_audio_pos {
+                        self.last_observed_audio_pos = audio_pos;
+                        self.last_audio_pos_change = Some(now);
+                        if self.audio_sync_stale {
+                            self.audio_sync_stale = false;
+                            // Re-anchor wall-clock to current audio position
+                            // so we don't jump when switching back to audio later
+                            self.playback_start_position = audio_pos;
+                            self.playback_start_time = Some(now);
+                            tracing::info!(
+                                "sync_position: audio recovered from stale, re-anchored to {:?}",
+                                audio_pos,
+                            );
+                        }
+                    } else if let Some(last_change) = self.last_audio_pos_change {
+                        if now.duration_since(last_change) > AUDIO_STALE_THRESHOLD
+                            && !self.audio_sync_stale
+                        {
+                            self.audio_sync_stale = true;
+                            // Re-anchor wall-clock to frozen audio position
+                            // so video continues smoothly from where audio stopped
+                            self.playback_start_position = audio_pos;
+                            self.playback_start_time = Some(now);
+                            tracing::warn!(
+                                "sync_position: audio stale for {:?}, falling back to wall-clock (audio_pos={:?})",
+                                now.duration_since(last_change),
+                                audio_pos,
+                            );
+                        }
+                    }
+
+                    if !self.audio_sync_stale {
+                        return audio_pos;
+                    }
+                    // Fall through to wall-clock when stale
                 } else {
                     // Audio available but not started yet (position == 0).
                     // Return playback_start_position to hold video at first frame
@@ -1738,7 +1809,7 @@ impl FrameScheduler {
         // EMA-smooth the raw drift signal (alpha=0.3, ~1s window at 200ms intervals)
         let raw_drift = self.sync_metrics.current_drift_us() as f64;
 
-        // Step detection: large drift (>200ms) indicates sudden desync from app
+        // Step detection: large drift (>100ms) indicates sudden desync from app
         // backgrounding or similar disruption. The proportional controller's 10ms/s
         // max slew would take ~100s to correct a 1s step. Instead, resync the wall
         // clock to the audio position immediately.
@@ -1761,7 +1832,8 @@ impl FrameScheduler {
         }
 
         const EMA_ALPHA: f64 = 0.3;
-        self.smoothed_drift_us = self.smoothed_drift_us * (1.0 - EMA_ALPHA) + raw_drift * EMA_ALPHA;
+        self.smoothed_drift_us =
+            self.smoothed_drift_us * (1.0 - EMA_ALPHA) + raw_drift * EMA_ALPHA;
         let drift_us = self.smoothed_drift_us as i64;
 
         // Hysteresis deadband: enter at |drift| > 40ms, exit at < 20ms
@@ -2365,6 +2437,17 @@ impl FrameScheduler {
                             threshold
                         );
                     }
+                    // Rebase wall-clock to the deferred threshold (= audio_base_pts).
+                    // During burst consumption, wall-clock advanced while audio was
+                    // gated (epoch not started). Without this rebase, the accumulated
+                    // wall-clock offset persists as permanent A/V drift.
+                    // Audio position starts at base_pts + 0 (samples_played was just
+                    // reset). Using threshold (not frame.pts) ensures wall-clock and
+                    // audio start from the exact same content position — zero offset.
+                    // frame.pts may overshoot threshold by up to one GOP interval;
+                    // using it would create a constant video-leads-audio offset.
+                    self.playback_start_position = threshold;
+                    self.playback_start_time = Some(std::time::Instant::now());
                     self.deferred_epoch_pts = None;
                 }
             }

--- a/crates/lumina-video-core/src/player.rs
+++ b/crates/lumina-video-core/src/player.rs
@@ -409,6 +409,7 @@ impl CorePlayer {
             thread.set_muted(self.audio_handle.is_muted());
             thread.play();
             self.scheduler.start();
+            self.audio_handle.set_paused(false);
             self.state = VideoState::Playing {
                 position: self.scheduler.position(),
             };
@@ -431,6 +432,7 @@ impl CorePlayer {
             thread.set_muted(muted);
             thread.play();
             self.scheduler.start();
+            self.audio_handle.set_paused(false);
             self.state = VideoState::Playing {
                 position: self.scheduler.position(),
             };
@@ -446,6 +448,7 @@ impl CorePlayer {
         if let Some(ref thread) = self.decode_thread {
             thread.pause();
             self.scheduler.pause();
+            self.audio_handle.set_paused(true);
             self.state = VideoState::Paused {
                 position: self.scheduler.position(),
             };

--- a/crates/lumina-video-ios/Cargo.toml
+++ b/crates/lumina-video-ios/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["staticlib", "lib"]
 lumina-video-core = { path = "../lumina-video-core" }
 parking_lot = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
 cpal = { workspace = true }

--- a/crates/lumina-video-ios/src/handle.rs
+++ b/crates/lumina-video-ios/src/handle.rs
@@ -12,13 +12,20 @@ use lumina_video_core::video::VideoFrame;
 #[cfg(feature = "moq")]
 use lumina_video_core::video::{VideoDecoderBackend, VideoError};
 
+/// Payload sent from the MoQ init thread when decoder creation completes.
+#[cfg(feature = "moq")]
+pub(crate) struct MoqInitResult {
+    pub decoder: Box<dyn VideoDecoderBackend + Send>,
+    pub stats: lumina_video::media::MoqStatsHandle,
+}
+
 /// State for async MoQ decoder initialization.
 ///
 /// `MoqDecoder::new_with_config()` blocks while connecting to the relay, so we
 /// run it on a background thread and poll for completion from FFI entry points.
 #[cfg(feature = "moq")]
 pub(crate) struct MoqInitState {
-    pub rx: std::sync::mpsc::Receiver<Result<Box<dyn VideoDecoderBackend + Send>, VideoError>>,
+    pub rx: std::sync::mpsc::Receiver<Result<MoqInitResult, VideoError>>,
     pub url: String,
 }
 
@@ -28,9 +35,19 @@ pub(crate) struct MoqInitState {
 /// lock exactly once, performs the operation, and releases. No nested locking.
 pub struct LuminaPlayer {
     pub(crate) core: Arc<Mutex<CorePlayer>>,
-    /// Pending MoQ decoder init (video-only, no audio).
+    /// Pending MoQ decoder init.
     #[cfg(feature = "moq")]
     pub(crate) moq_init: Mutex<Option<MoqInitState>>,
+    /// MoQ stats handle for audio late-binding (set after init completes).
+    #[cfg(feature = "moq")]
+    pub(crate) moq_stats: Mutex<Option<lumina_video::media::MoqStatsHandle>>,
+    /// Whether the MoQ audio handle has been late-bound to the CorePlayer.
+    #[cfg(feature = "moq")]
+    pub(crate) moq_audio_bound: std::sync::atomic::AtomicBool,
+    /// Whether the MoQ audio handle has been promoted to sync master
+    /// (only after observing samples_played > 0, proving audio is advancing).
+    #[cfg(feature = "moq")]
+    pub(crate) moq_audio_sync_master: std::sync::atomic::AtomicBool,
 }
 
 /// Opaque frame handle exposed via FFI.
@@ -64,13 +81,29 @@ impl LuminaPlayer {
         let Some(ref state) = *init else { return };
 
         match state.rx.try_recv() {
-            Ok(Ok(decoder)) => {
+            Ok(Ok(result)) => {
                 let url = state.url.clone();
                 *init = None;
                 drop(init);
-                let new_core = CorePlayer::with_decoder(url, decoder);
+
+                // Store stats handle for audio late-binding
+                *self.moq_stats.lock() = Some(result.stats);
+
+                let mut new_core = CorePlayer::with_decoder(url, result.decoder);
+                // No frame-rate pacing for MoQ — the deferred epoch rebase
+                // handles burst consumption. A fixed pacing rate (e.g. 30fps)
+                // causes drift when content fps differs (24fps BBB → 8ms/frame
+                // → ~250ms/sec A/V drift). Wall-clock acceptance naturally
+                // matches real-time for live frames after the rebase.
+                //
+                // Auto-play: MoQ live streams should start immediately.
+                // Swift called play() on the old shell CorePlayer before init
+                // completed — that play state is lost when we swap. Force-start
+                // the new CorePlayer so the decode thread isn't stuck in PAUSED.
+                let muted = new_core.audio_handle().is_muted();
+                new_core.play_with_muted(muted);
                 *self.core.lock() = new_core;
-                tracing::info!("MoQ decoder initialized successfully (video-only)");
+                tracing::info!("MoQ decoder initialized successfully (auto-playing)");
             }
             Ok(Err(e)) => {
                 tracing::error!("MoQ decoder init failed: {e}");
@@ -91,6 +124,96 @@ impl LuminaPlayer {
                     VideoError::Generic("MoQ init thread crashed".into()),
                 ));
             }
+        }
+    }
+
+    /// Polls the MoQ audio handle and late-binds it to the CorePlayer.
+    ///
+    /// Two-phase bind:
+    /// 1. **Metrics-only**: On first detection, start the epoch and bind for
+    ///    metrics/mute/volume, but wall-clock still drives frame pacing.
+    /// 2. **Sync master**: Once `samples_played > 0` (proving cpal passed the
+    ///    ring buffer prefill gate and is actually consuming audio), promote to
+    ///    audio-as-sync-master and re-anchor the scheduler clock to eliminate
+    ///    the wall-clock→audio discontinuity.
+    #[cfg(feature = "moq")]
+    pub(crate) fn poll_moq_audio_handle(&self) {
+        use std::sync::atomic::Ordering;
+
+        let stats = self.moq_stats.lock();
+        let Some(ref stats) = *stats else { return };
+
+        if let Some(moq_ah) = stats.audio_handle() {
+            let bound = self.moq_audio_bound.load(Ordering::Relaxed);
+            let is_sync_master = self.moq_audio_sync_master.load(Ordering::Relaxed);
+
+            if !bound {
+                // Phase 1: First detection — bind as metrics-only.
+                // Start the epoch so cpal begins consuming the ring buffer
+                // (it needs to pass the 500ms prefill gate before samples_played
+                // increments). Wall-clock still drives video pacing.
+                let mut core = self.core.lock();
+                let muted = core.audio_handle().is_muted();
+                let volume = core.audio_handle().volume();
+                moq_ah.set_muted(muted);
+                moq_ah.set_volume(volume);
+                moq_ah.set_available(true);
+                moq_ah.start_playback_epoch();
+
+                // Metrics-only: drift is measured but wall-clock drives pacing
+                core.scheduler_mut()
+                    .set_audio_handle_metrics_only(moq_ah.clone());
+
+                // Replace the player-level handle (for UI mute/volume controls)
+                core.set_audio_handle(moq_ah);
+                drop(core);
+
+                self.moq_audio_bound.store(true, Ordering::Relaxed);
+                tracing::info!(
+                    "MoQ audio: late-bound audio handle (metrics-only, epoch started)"
+                );
+            } else if !is_sync_master {
+                // Phase 2: Wait for audio progress, then promote to sync master.
+                // samples_played > 0 proves: epoch is set, ring buffer prefilled,
+                // cpal callback is reading samples. Safe to pace video off audio.
+                let samples = moq_ah.samples_played();
+                if samples > 0 {
+                    let audio_pos = moq_ah.position_for_sync();
+                    if audio_pos > std::time::Duration::ZERO {
+                        let mut core = self.core.lock();
+                        // Promote: flip wall-clock → audio-as-sync-master
+                        core.scheduler_mut()
+                            .set_audio_handle(moq_ah.clone());
+                        // Re-anchor the scheduler clock to the current audio
+                        // position. This eliminates the discontinuity between
+                        // where wall-clock had advanced to and where audio
+                        // actually is.
+                        core.scheduler_mut()
+                            .resync_clock_to_audio();
+                        drop(core);
+
+                        self.moq_audio_sync_master.store(true, Ordering::Relaxed);
+                        tracing::info!(
+                            "MoQ audio: promoted to sync master (samples_played={}, audio_pos={:?})",
+                            samples,
+                            audio_pos,
+                        );
+                    }
+                }
+            }
+        } else if self.moq_audio_bound.load(Ordering::Relaxed) {
+            // Audio thread torn down — unbind
+            let mut core = self.core.lock();
+            let placeholder = lumina_video_core::audio::AudioHandle::new();
+            placeholder.set_muted(core.audio_handle().is_muted());
+            placeholder.set_volume(core.audio_handle().volume());
+            core.set_audio_handle(placeholder);
+            core.scheduler_mut().clear_audio_handle();
+            drop(core);
+
+            self.moq_audio_bound.store(false, Ordering::Relaxed);
+            self.moq_audio_sync_master.store(false, Ordering::Relaxed);
+            tracing::info!("MoQ audio: unbound stale audio handle");
         }
     }
 }

--- a/crates/lumina-video-ios/src/lib.rs
+++ b/crates/lumina-video-ios/src/lib.rs
@@ -91,6 +91,12 @@ pub extern "C" fn lumina_player_create(
             core: Arc::new(Mutex::new(core)),
             #[cfg(feature = "moq")]
             moq_init: Mutex::new(None),
+            #[cfg(feature = "moq")]
+            moq_stats: Mutex::new(None),
+            #[cfg(feature = "moq")]
+            moq_audio_bound: std::sync::atomic::AtomicBool::new(false),
+            #[cfg(feature = "moq")]
+            moq_audio_sync_master: std::sync::atomic::AtomicBool::new(false),
         });
 
         let raw = Box::into_raw(player);
@@ -115,16 +121,15 @@ fn create_moq_player(
     url_str: &str,
     out_player: *mut *mut LuminaPlayer,
 ) -> Result<(), LuminaError> {
-    use crate::handle::MoqInitState;
+    use crate::handle::{MoqInitResult, MoqInitState};
     use lumina_video::media::{MoqDecoder, MoqDecoderConfig};
 
     tracing::info!("Creating MoQ player for: {url_str}");
 
     let mut config = MoqDecoderConfig::default();
-    // Disable audio — iOS MoQ is video-only for now
-    config.enable_audio = false;
-    // TODO: gate behind debug_assertions once real TLS certs are used in production
-    config.transport.disable_tls_verify = true;
+    config.enable_audio = true;
+    // Only disable TLS verify in debug builds (self-signed relay certs)
+    config.transport.disable_tls_verify = cfg!(debug_assertions);
 
     let url_owned = url_str.to_string();
     let (tx, rx) = std::sync::mpsc::channel();
@@ -135,8 +140,14 @@ fn create_moq_player(
             let url = url_owned.clone();
             move || {
                 tracing::info!("MoQ init thread: connecting to {url}");
-                let result = MoqDecoder::new_with_config(&url, config)
-                    .map(|d| Box::new(d) as Box<dyn lumina_video_core::video::VideoDecoderBackend + Send>);
+                let result = MoqDecoder::new_with_config(&url, config).map(|d| {
+                    let stats = d.stats_handle();
+                    MoqInitResult {
+                        decoder: Box::new(d)
+                            as Box<dyn lumina_video_core::video::VideoDecoderBackend + Send>,
+                        stats,
+                    }
+                });
                 if let Err(ref e) = result {
                     tracing::error!("MoQ decoder creation failed: {e}");
                 }
@@ -153,6 +164,9 @@ fn create_moq_player(
     let player = Box::new(LuminaPlayer {
         core: Arc::new(Mutex::new(core)),
         moq_init: Mutex::new(Some(MoqInitState { rx, url: url_owned })),
+        moq_stats: Mutex::new(None),
+        moq_audio_bound: std::sync::atomic::AtomicBool::new(false),
+        moq_audio_sync_master: std::sync::atomic::AtomicBool::new(false),
     });
 
     let raw = Box::into_raw(player);
@@ -423,6 +437,8 @@ pub extern "C" fn lumina_player_poll_frame(player: *mut LuminaPlayer) -> *mut Lu
         let player = unsafe { &*player };
         #[cfg(feature = "moq")]
         player.try_complete_moq_init();
+        #[cfg(feature = "moq")]
+        player.poll_moq_audio_handle();
         let frame = {
             let mut core = player.core.lock();
             // Drive init forward if needed
@@ -607,6 +623,80 @@ pub extern "C" fn lumina_diagnostics_snapshot(out: *mut LuminaDiagnostics) -> i3
 
         Ok(())
     })
+}
+
+// =========================================================================
+// MoQ audio diagnostics
+// =========================================================================
+
+/// Returns the MoQ audio status as an integer.
+///
+/// - 0: Not a MoQ stream (VOD) or MoQ feature not enabled
+/// - 1: Unavailable (audio not in catalog or not yet started)
+/// - 2: Starting (audio thread spawning)
+/// - 3: Running (cpal stream active)
+/// - 4: Error (audio thread failed)
+/// - 5: Handle bound (audio handle late-bound to player)
+///
+/// # Safety
+/// `player` must be a valid `LuminaPlayer` pointer (or NULL).
+#[no_mangle]
+pub extern "C" fn lumina_player_moq_audio_status(player: *const LuminaPlayer) -> i32 {
+    ffi_boundary_or(0, || {
+        if player.is_null() {
+            return 0;
+        }
+        #[cfg(feature = "moq")]
+        {
+            let player = unsafe { &*player };
+            let stats = player.moq_stats.lock();
+            if let Some(ref stats) = *stats {
+                if player
+                    .moq_audio_bound
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                {
+                    return 5; // Handle bound
+                }
+                // Check if audio handle is available (thread alive)
+                if stats.audio_handle().is_some() {
+                    return 3; // Running but not yet bound
+                }
+                if stats.is_audio_alive() {
+                    return 2; // Starting
+                }
+                return 1; // Unavailable
+            }
+            0 // No MoQ stats yet
+        }
+        #[cfg(not(feature = "moq"))]
+        0
+    })
+}
+
+// =========================================================================
+// Tracing / logging
+// =========================================================================
+
+/// Initializes the Rust tracing subscriber (logs to stderr → Xcode console).
+///
+/// Call once at app startup before any player creation. Subsequent calls
+/// are no-ops (guarded by `std::sync::Once`).
+///
+/// # Safety
+/// No pointer arguments — always safe to call.
+#[no_mangle]
+pub extern "C" fn lumina_init_tracing() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_target(true)
+            .with_thread_ids(true)
+            .with_ansi(false)
+            .init();
+        tracing::info!("lumina_init_tracing: subscriber initialized");
+    });
 }
 
 // =========================================================================

--- a/crates/lumina-video/Cargo.toml
+++ b/crates/lumina-video/Cargo.toml
@@ -124,7 +124,6 @@ block2 = { workspace = true }
 objc2-core-foundation = { version = "0.3", features = ["CFNumber", "CFDictionary", "CFString"] }
 metal = { workspace = true }
 wgpu = { version = "24" }
-profiling = { version = "1.0" }
 cpal = { workspace = true }
 opus = { workspace = true }
 symphonia-codec-aac = { workspace = true }
@@ -171,17 +170,17 @@ optional = true
 # MoQ crates from kixelated/moq (the active repo, moq-rs is archived)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.moq-lite]
 git = "https://github.com/kixelated/moq"
-rev = "baabd55c7a8dd6c85d6e1e329a776208bd1107ca"
+rev = "ca7fb4bc37c2b01fe5fb2ee735c5511e62b531ce"
 optional = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.moq-native]
 git = "https://github.com/kixelated/moq"
-rev = "baabd55c7a8dd6c85d6e1e329a776208bd1107ca"
+rev = "ca7fb4bc37c2b01fe5fb2ee735c5511e62b531ce"
 optional = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.hang]
 git = "https://github.com/kixelated/moq"
-rev = "baabd55c7a8dd6c85d6e1e329a776208bd1107ca"
+rev = "ca7fb4bc37c2b01fe5fb2ee735c5511e62b531ce"
 optional = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.async-channel]

--- a/crates/lumina-video/src/media/moq/worker.rs
+++ b/crates/lumina-video/src/media/moq/worker.rs
@@ -313,10 +313,14 @@ async fn resubscribe_video_track(
         detail,
     );
 
-    *video_consumer = hang::container::OrderedConsumer::new(
-        moq_broadcast.subscribe_track(video_track),
-        max_latency,
-    );
+    let track_consumer = match moq_broadcast.subscribe_track(video_track) {
+        Ok(tc) => tc,
+        Err(e) => {
+            tracing::error!("MoQ {}: Failed to re-subscribe video track: {}", label, e);
+            return false;
+        }
+    };
+    *video_consumer = hang::container::OrderedConsumer::new(track_consumer, max_latency);
 
     // Audio runs in its own dedicated task and is not re-subscribed here.
 
@@ -397,7 +401,7 @@ pub(crate) async fn run_moq_worker(
         priority: 100,
     };
     let mut video_consumer = hang::container::OrderedConsumer::new(
-        moq_broadcast.subscribe_track(&video_track),
+        moq_broadcast.subscribe_track(&video_track)?,
         cat.max_latency,
     );
 
@@ -667,7 +671,7 @@ pub(crate) async fn run_moq_worker(
                         // Frame dump: record then check if we should disable
                         let mut disable_dump = false;
                         if let Some(ref mut dump) = frame_dump {
-                            match dump.record_frame(&data, frame.keyframe, frame.timestamp.as_micros() as u64) {
+                            match dump.record_frame(&data, frame.is_keyframe(), frame.timestamp.as_micros() as u64) {
                                 Ok(false) => disable_dump = true,
                                 Err(e) => {
                                     tracing::warn!("FrameDumpHook: I/O error ({}), disabling dump", e);
@@ -685,7 +689,7 @@ pub(crate) async fn run_moq_worker(
                             let start = *idr_gate_start.get_or_insert_with(std::time::Instant::now);
 
                             // Log first few keyframes BEFORE gate decision for diagnostics
-                            if frame.keyframe && idr_gate_groups_seen < 5 {
+                            if frame.is_keyframe() && idr_gate_groups_seen < 5 {
                                 let n = data.len().min(20);
                                 let is_avcc_fmt = idr_gate_enabled;
                                 let (nal_arr, nal_count) =
@@ -700,7 +704,7 @@ pub(crate) async fn run_moq_worker(
                                 );
                             }
 
-                            if frame.keyframe {
+                            if frame.is_keyframe() {
                                 idr_gate_groups_seen = idr_gate_groups_seen.saturating_add(1);
                             }
                             let elapsed = start.elapsed();
@@ -715,7 +719,7 @@ pub(crate) async fn run_moq_worker(
                                 MoqDecoder::find_nal_types_for_format(&data, nal_length_size, is_avcc);
                             let has_idr = nal_arr[..nal_count].contains(&5);
 
-                            if frame.keyframe && has_idr {
+                            if frame.is_keyframe() && has_idr {
                                 // Best case: real IDR at group boundary.
                                 tracing::info!(
                                     "MoQ {}: IDR gate cleared — real IDR at {}ms (groups_seen={})",
@@ -726,7 +730,7 @@ pub(crate) async fn run_moq_worker(
                                 waiting_for_valid_idr = false;
                                 idr_gate_broken_keyframes = 0;
                             } else {
-                                if frame.keyframe && !has_idr {
+                                if frame.is_keyframe() && !has_idr {
                                     idr_gate_broken_keyframes =
                                         idr_gate_broken_keyframes.saturating_add(1);
                                     tracing::warn!(
@@ -795,7 +799,7 @@ pub(crate) async fn run_moq_worker(
                         let moq_frame = MoqVideoFrame {
                             timestamp_us: frame.timestamp.as_micros() as u64,
                             data,
-                            is_keyframe: frame.keyframe,
+                            is_keyframe: frame.is_keyframe(),
                         };
 
                         if recv_count <= 10 {
@@ -1297,7 +1301,7 @@ async fn fetch_and_validate_catalog(
     label: &str,
 ) -> Result<CatalogResult, Box<dyn std::error::Error + Send + Sync>> {
     let mut catalog_consumer =
-        hang::CatalogConsumer::new(moq_broadcast.subscribe_track(&hang::Catalog::default_track()));
+        hang::CatalogConsumer::new(moq_broadcast.subscribe_track(&hang::Catalog::default_track())?);
     let catalog_timeout = Duration::from_secs(5);
     let catalog = match tokio::time::timeout(catalog_timeout, catalog_consumer.next()).await {
         Ok(Ok(Some(catalog))) => catalog,
@@ -1499,10 +1503,17 @@ fn setup_audio(
         name: track_name.to_string(),
         priority: 50,
     };
-    let audio_consumer = hang::container::OrderedConsumer::new(
-        moq_broadcast.subscribe_track(&audio_track),
-        max_latency,
-    );
+    let track_consumer = match moq_broadcast.subscribe_track(&audio_track) {
+        Ok(tc) => tc,
+        Err(e) => {
+            tracing::error!("MoQ {}: Failed to subscribe audio track: {}", label, e);
+            *shared.audio.audio_status.lock() = MoqAudioStatus::Unavailable;
+            return (None, None, None);
+        }
+    };
+    // Audio should never skip frames — use a large max_latency so OrderedConsumer
+    // delivers every frame without latency-based group skipping.
+    let audio_consumer = hang::container::OrderedConsumer::new(track_consumer, Duration::from_secs(30));
 
     let (tx, rx) = crossbeam_channel::bounded(config.audio_buffer_capacity);
     let live_sender = LiveEdgeSender::new(tx, rx.clone());
@@ -1595,8 +1606,26 @@ fn spawn_audio_forward_task(
         // select! loop provides defense-in-depth if this timeout fails to fire.
         const READ_TIMEOUT: Duration = Duration::from_secs(8);
         let mut last_periodic_log = std::time::Instant::now();
+        let mut max_read_us: u64 = 0;
+        let mut total_read_us: u64 = 0;
         loop {
-            match tokio::time::timeout(READ_TIMEOUT, audio_consumer.read()).await {
+            let read_start = std::time::Instant::now();
+            let result = tokio::time::timeout(READ_TIMEOUT, audio_consumer.read()).await;
+            let read_elapsed_us = read_start.elapsed().as_micros() as u64;
+            total_read_us += read_elapsed_us;
+            if read_elapsed_us > max_read_us {
+                max_read_us = read_elapsed_us;
+            }
+            // Log any read that takes >100ms — early warning of blocking
+            if read_elapsed_us > 100_000 {
+                tracing::warn!(
+                    "MoQ {}: audio read() took {}ms (frames so far: {})",
+                    label_owned,
+                    read_elapsed_us / 1000,
+                    frames_forwarded,
+                );
+            }
+            match result {
                 Ok(Ok(Some(frame))) => {
                     let data = assemble_payload(&frame.payload, &mut buf);
                     let pts_us = frame.timestamp.as_micros() as u64;
@@ -1623,34 +1652,39 @@ fn spawn_audio_forward_task(
                     // Periodic log every 5s to confirm liveness
                     if last_periodic_log.elapsed() >= Duration::from_secs(5) {
                         last_periodic_log = std::time::Instant::now();
+                        let avg_read_us = if frames_forwarded > 0 { total_read_us / frames_forwarded } else { 0 };
                         tracing::info!(
-                            "MoQ {}: audio forward alive: {} frames forwarded, last_pts={}us",
+                            "MoQ {}: audio forward alive: {} frames, last_pts={}us, avg_read={}us, max_read={}us",
                             label_owned,
                             frames_forwarded,
                             pts_us,
+                            avg_read_us,
+                            max_read_us,
                         );
                     }
                 }
                 Ok(Ok(None)) => {
-                    tracing::info!(
-                        "MoQ {}: Audio track ended (after {} frames)",
+                    tracing::warn!(
+                        "MoQ {}: Audio track ended (after {} frames, last read took {}ms)",
                         label_owned,
                         frames_forwarded,
+                        read_elapsed_us / 1000,
                     );
                     break;
                 }
                 Ok(Err(e)) => {
                     tracing::warn!(
-                        "MoQ {}: Audio read error (after {} frames): {e}",
+                        "MoQ {}: Audio read error (after {} frames, last read took {}ms): {e}",
                         label_owned,
                         frames_forwarded,
+                        read_elapsed_us / 1000,
                     );
                     break;
                 }
                 Err(_elapsed) => {
                     // Single strike — exit immediately, don't reuse corrupted consumer
                     tracing::warn!(
-                        "MoQ {}: Audio read timeout ({}s, after {} frames) — consumer stalled, exiting for re-subscribe",
+                        "MoQ {}: Audio read TIMEOUT ({}s, after {} frames) — consumer stalled, exiting for re-subscribe",
                         label_owned,
                         READ_TIMEOUT.as_secs(),
                         frames_forwarded,

--- a/crates/lumina-video/src/media/moq_audio.rs
+++ b/crates/lumina-video/src/media/moq_audio.rs
@@ -327,6 +327,36 @@ const MAX_CONSECUTIVE_DECODE_ERRORS: u32 = 100;
 /// this, insert silence to keep the ring buffer timeline correct.
 const GAP_THRESHOLD_US: u64 = 32_000; // 32ms
 
+/// Linear interpolation resampler for PCM audio.
+///
+/// Converts interleaved f32 samples from `in_rate` to `out_rate`. Handles arbitrary
+/// channel counts. No state between calls — suitable for independent frame-by-frame
+/// resampling where sub-sample continuity is not critical (ring buffer absorbs jitter).
+fn linear_resample(input: &[f32], channels: usize, in_rate: u32, out_rate: u32) -> Vec<f32> {
+    if in_rate == out_rate || input.is_empty() || channels == 0 {
+        return input.to_vec();
+    }
+    let in_frames = input.len() / channels;
+    let out_frames =
+        ((in_frames as u64) * (out_rate as u64) + (in_rate as u64 - 1)) / (in_rate as u64);
+    let ratio = in_rate as f64 / out_rate as f64;
+    let mut output = Vec::with_capacity(out_frames as usize * channels);
+    for i in 0..out_frames as usize {
+        let src_pos = i as f64 * ratio;
+        let idx = src_pos as usize;
+        let frac = (src_pos - idx as f64) as f32;
+        for ch in 0..channels {
+            let s0 = input.get(idx * channels + ch).copied().unwrap_or(0.0);
+            let s1 = input
+                .get((idx + 1) * channels + ch)
+                .copied()
+                .unwrap_or(s0);
+            output.push(s0 + (s1 - s0) * frac);
+        }
+    }
+    output
+}
+
 /// Audio thread main loop: receives AAC frames, decodes via symphonia, writes to ring buffer.
 ///
 /// Uses a lock-free ring buffer read by the cpal audio callback,
@@ -364,6 +394,19 @@ fn moq_audio_thread_main(
         }
     };
 
+    // Detect sample rate mismatch: iOS devices only support 48kHz, so when
+    // content is 44.1kHz, cpal falls back to device rate. Without resampling,
+    // the ring buffer drains ~8.8% faster than it fills → constant underruns.
+    let device_rate = player.device_sample_rate();
+    let needs_resample = device_rate != sample_rate;
+    if needs_resample {
+        tracing::info!(
+            "MoQ audio: content rate {}Hz != device rate {}Hz, will resample",
+            sample_rate,
+            device_rate,
+        );
+    }
+
     let mut decoder = match codec {
         MoqAudioCodec::Aac => {
             match SymphoniaAacDecoder::new(sample_rate, channels, description.as_ref()) {
@@ -393,7 +436,9 @@ fn moq_audio_thread_main(
         },
     };
 
-    audio_handle.set_audio_format(sample_rate, channels);
+    // Use device rate for position tracking: cpal reads at device_rate,
+    // so samples_played / device_rate gives correct wall-clock position.
+    audio_handle.set_audio_format(device_rate, channels);
 
     audio_shared
         .internal_audio_ready
@@ -450,6 +495,8 @@ fn moq_audio_thread_main(
 
                     // Gap detection: insert silence for PTS discontinuities > 32ms.
                     // Capped at 1s AND available buffer space to avoid overflow.
+                    // PTS math uses content sample_rate; silence uses device_rate
+                    // (ring buffer runs at device rate when resampling).
                     if let Some(prev_pts) = last_pts_us {
                         let expected_next = prev_pts
                             + (samples.data.len() as u64 * 1_000_000)
@@ -458,13 +505,11 @@ fn moq_audio_thread_main(
                         if actual > expected_next + GAP_THRESHOLD_US {
                             let gap_us = actual - expected_next;
                             let silence_samples =
-                                (gap_us as usize * sample_rate as usize * ch) / 1_000_000;
-                            // Cap at 1s, and also at available buffer space to prevent
-                            // silence from overflowing and overwriting valid audio.
+                                (gap_us as usize * device_rate as usize * ch) / 1_000_000;
                             let available =
                                 producer.capacity().saturating_sub(producer.fill_level());
                             let capped = silence_samples
-                                .min(sample_rate as usize * ch)
+                                .min(device_rate as usize * ch)
                                 .min(available);
                             if capped > 0 {
                                 let silence = vec![0.0f32; capped];
@@ -495,8 +540,17 @@ fn moq_audio_thread_main(
                         std::thread::sleep(Duration::from_millis(5));
                     }
 
-                    // Write decoded PCM directly to ring buffer (lock-free)
-                    producer.write(&samples.data);
+                    // Write decoded PCM to ring buffer, resampling if needed.
+                    // When device rate differs from content rate (e.g. 44.1kHz
+                    // content on 48kHz-only iOS), linear interpolation prevents
+                    // the ring buffer from draining faster than it fills.
+                    if needs_resample {
+                        let resampled =
+                            linear_resample(&samples.data, ch, sample_rate, device_rate);
+                        producer.write(&resampled);
+                    } else {
+                        producer.write(&samples.data);
+                    }
 
                     // Periodically flush ring buffer metrics for UI observability (~1/sec)
                     frames_since_metrics += 1;

--- a/ios/lumina-video-bridge/CHeaders/include/LuminaVideo.h
+++ b/ios/lumina-video-bridge/CHeaders/include/LuminaVideo.h
@@ -269,6 +269,36 @@ typedef struct LuminaDiagnostics {
  */
 LuminaError lumina_diagnostics_snapshot(LuminaDiagnostics *out);
 
+/* ========================================================================= */
+/* MoQ audio diagnostics                                                      */
+/* ========================================================================= */
+
+/**
+ * Returns MoQ audio pipeline status.
+ *
+ * - 0: Not a MoQ stream or MoQ feature not enabled
+ * - 1: Unavailable (audio not in catalog or not yet started)
+ * - 2: Starting (audio thread spawning)
+ * - 3: Running (cpal stream active)
+ * - 4: Error (audio thread failed)
+ * - 5: Handle bound (audio handle late-bound to player)
+ *
+ * @param player    Valid player handle. Returns 0 if NULL.
+ */
+int32_t lumina_player_moq_audio_status(const LuminaPlayer *player);
+
+/* ========================================================================= */
+/* Tracing / logging                                                          */
+/* ========================================================================= */
+
+/**
+ * Initializes the Rust tracing subscriber (logs to stderr).
+ *
+ * Call once at app startup, before any player creation. Safe to call
+ * multiple times (subsequent calls are no-ops).
+ */
+void lumina_init_tracing(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ios/lumina-video-bridge/Sources/LuminaVideoBridge/LuminaVideoPlayer.swift
+++ b/ios/lumina-video-bridge/Sources/LuminaVideoBridge/LuminaVideoPlayer.swift
@@ -115,6 +115,15 @@ public final class LuminaVideoPlayer: ObservableObject {
     ///   - audioSessionConfig: Audio session configuration. Defaults to `.default`.
     /// - Throws: `LuminaVideoError` if the URL is invalid or creation fails.
     public init(url: String, audioSessionConfig: AudioSessionConfig = .default) throws {
+        // Initialize Rust tracing subscriber (stderr → Xcode console).
+        // Guarded by Once internally — safe to call multiple times.
+        lumina_init_tracing()
+
+        // Configure audio session BEFORE player creation.
+        // MoQ spawns a background thread immediately — if the relay connects fast,
+        // cpal could try to open the audio device before the session is active.
+        configureAudioSession(audioSessionConfig)
+
         var ptr: OpaquePointer?
         let err = url.withCString { cStr in
             lumina_player_create(cStr, &ptr)
@@ -123,9 +132,6 @@ public final class LuminaVideoPlayer: ObservableObject {
             throw LuminaVideoError(rawValue: err) ?? .internal
         }
         self.playerPtr = validPtr
-
-        // Configure audio session
-        configureAudioSession(audioSessionConfig)
 
         // Sync initial mute state to Rust player
         lumina_player_set_muted(validPtr, is_muted)
@@ -166,6 +172,12 @@ public final class LuminaVideoPlayer: ObservableObject {
     public func seek(to position: TimeInterval) {
         guard let ptr = playerPtr else { return }
         lumina_player_seek(ptr, position)
+    }
+
+    /// MoQ audio pipeline status (0=N/A, 1=unavail, 2=starting, 3=running, 4=error, 5=bound).
+    public var moq_audio_status: Int32 {
+        guard let ptr = playerPtr else { return 0 }
+        return lumina_player_moq_audio_status(ptr)
     }
 
     // MARK: - Audio session

--- a/ios/test-harness/LuminaTestHarness/ContentView.swift
+++ b/ios/test-harness/LuminaTestHarness/ContentView.swift
@@ -15,7 +15,7 @@ struct ContentView: View {
             }
         }
         .onAppear {
-            viewModel.load(url: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8")
+            viewModel.load(url: "moq://192.168.8.219:4443/anon/bbb")
         }
         .statusBarHidden(isFullscreen)
     }
@@ -191,6 +191,10 @@ struct DiagnosticsPanel: View {
                     value: String(format: "%.1f", viewModel.measuredFPS))
             DiagRow(label: "A/V sync",
                     value: viewModel.isLive ? viewModel.clockDriftLabel : "AVPlayer (native)")
+            if viewModel.isLive {
+                DiagRow(label: "MoQ audio",
+                        value: viewModel.moqAudioStatus)
+            }
         }
         .padding(10)
         .background(Color(.secondarySystemBackground))
@@ -235,6 +239,7 @@ final class VideoViewModel: ObservableObject {
     @Published var nominalFPS: Float?
     @Published var measuredFPS: Double = 0
     @Published var clockDriftLabel: String = "—"
+    @Published var moqAudioStatus: String = "—"
 
     /// True for live streams (MoQ), false for VOD (HLS/MP4). Clock drift only shown for live.
     var isLive: Bool { duration == nil }
@@ -357,6 +362,22 @@ final class VideoViewModel: ObservableObject {
         let posElapsed = currentTime - startPos
         let drift = (posElapsed - wallElapsed) * 1000.0 // ms
         clockDriftLabel = String(format: "%+.0f ms", drift)
+    }
+
+    // MARK: - MoQ audio status
+
+    private func updateMoqAudioStatus() {
+        guard let player else { return }
+        let status = player.moq_audio_status
+        switch status {
+        case 0: moqAudioStatus = "N/A"
+        case 1: moqAudioStatus = "Unavailable"
+        case 2: moqAudioStatus = "Starting"
+        case 3: moqAudioStatus = "Running"
+        case 4: moqAudioStatus = "Error"
+        case 5: moqAudioStatus = "Bound"
+        default: moqAudioStatus = "Unknown (\(status))"
+        }
     }
 
     // MARK: - Media info probing
@@ -503,14 +524,21 @@ extension VideoViewModel: LuminaVideoPlayerDelegate {
             // Render path: zero-copy if IOSurface present
             self.renderPath = frame.ioSurface != nil ? "Zero-copy (IOSurface)" : "CPU fallback"
 
-            // FPS + A/V sync
+            // FPS + A/V sync (only after second frame to avoid PTS jump artifact)
             self.recordFrameArrival()
-            if self.isPlaying {
+            if self.isPlaying && !isFirst {
                 self.updateAVSync()
             }
 
+            // MoQ audio status
+            self.updateMoqAudioStatus()
+
             if isFirst {
                 self.videoSize = player.video_size
+                // Reset A/V sync so calibration starts from the first frame's position,
+                // avoiding a false +Nms jump from publisher-absolute PTS.
+                self.playbackStartWall = nil
+                self.playbackStartPosition = nil
             }
         }
     }

--- a/tests/ios-smoke-test/CpalSmokeTest/CpalSmokeTest.xcodeproj/project.pbxproj
+++ b/tests/ios-smoke-test/CpalSmokeTest/CpalSmokeTest.xcodeproj/project.pbxproj
@@ -220,7 +220,8 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../../../target/aarch64-apple-ios/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/../../../target/aarch64-apple-ios/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = "$(SRCROOT)/../../../target/aarch64-apple-ios-sim/release";
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.luminavideo.CpalSmokeTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -243,7 +244,8 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../../../target/aarch64-apple-ios/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/../../../target/aarch64-apple-ios/release";
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = "$(SRCROOT)/../../../target/aarch64-apple-ios-sim/release";
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.luminavideo.CpalSmokeTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Summary
- **iOS MoQ audio**: enable audio on iOS with late-bound audio handle, polled per-frame via `poll_moq_audio_handle()`
- **Linear resampler**: 44.1kHz→48kHz content resampling for iOS devices (cpal only supports device native rate)
- **Stale audio sync**: fall back to wall-clock if audio position stops advancing for >2s, re-anchor seamlessly on recovery
- **MoQ draft-17 API updates**: `subscribe_track()` now returns `Result`, `frame.is_keyframe()` replaces `.keyframe`
- **FFI diagnostics**: `lumina_player_moq_audio_status()` + Swift bridge for audio state visibility in test harness

## Test plan
- [ ] `cargo check -p lumina-video --features moq` compiles clean
- [ ] `cargo check -p lumina-video-ios --features moq` compiles clean
- [ ] MoQ audio plays on iOS physical device with 48kHz content
- [ ] MoQ audio plays on iOS with 44.1kHz content (resampling path)
- [ ] Stale audio detection triggers after 2s of frozen audio position
- [ ] Audio recovery re-anchors wall-clock without video jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)